### PR TITLE
Proactive Aliasing and Defer Cache Nesting

### DIFF
--- a/gc/base/CopyScanCache.hpp
+++ b/gc/base/CopyScanCache.hpp
@@ -68,7 +68,7 @@ class MM_CopyScanCache : public MM_Base {
 private:
 protected:
 public:
-	MM_CopyScanCacheStandard* nextDefer; //Temp: TODO - look into using something for stack pointer
+	
 	MM_CopyScanCache* next;
 	uintptr_t flags;
 	bool _hasPartiallyScannedObject; /**< whether the current object been scanned is partially scanned */
@@ -76,6 +76,8 @@ public:
 	void* cacheTop;
 	void* cacheAlloc;
 	void* scanCurrent;
+	
+	MM_CopyScanCacheStandard* nextDefer; //Temp: TODO - look into using something for stack pointer
 
 	/* Members Function */
 private:
@@ -124,6 +126,7 @@ public:
 		, cacheTop(NULL)
 		, cacheAlloc(NULL)
 		, scanCurrent(NULL)
+		, nextDefer(NULL)
 	{
 	}
 
@@ -136,6 +139,7 @@ public:
 		, cacheTop(NULL)
 		, cacheAlloc(NULL)
 		, scanCurrent(NULL)
+		, nextDefer(NULL)
 	{
 	}
 };

--- a/gc/base/CopyScanCache.hpp
+++ b/gc/base/CopyScanCache.hpp
@@ -57,6 +57,7 @@
 #include "Base.hpp"
 #include "ObjectIteratorState.hpp"
 
+class MM_CopyScanCacheStandard;
 /**
  * @todo Provide class documentation
  * @ingroup GC_Base_Core
@@ -67,6 +68,7 @@ class MM_CopyScanCache : public MM_Base {
 private:
 protected:
 public:
+	MM_CopyScanCacheStandard* nextDefer; //Temp: TODO - look into using something for stack pointer
 	MM_CopyScanCache* next;
 	uintptr_t flags;
 	bool _hasPartiallyScannedObject; /**< whether the current object been scanned is partially scanned */

--- a/gc/base/EnvironmentBase.hpp
+++ b/gc/base/EnvironmentBase.hpp
@@ -113,6 +113,7 @@ protected:
 #endif /* OMR_GC_SEGREGATED_HEAP */
 
 public:
+	uintptr_t _deferredScanDepth;
 	/**
 	 * Codes used to identify attached VM threads.
 	 *
@@ -612,6 +613,7 @@ public:
 		,_regionLocalFree(NULL)
 		,_regionLocalFull(NULL)
 #endif /* OMR_GC_SEGREGATED_HEAP */
+		,_deferredScanDepth(0)
 		,_objectAllocationInterface(NULL)
 		,_workStack()
 		,_threadType(MUTATOR_THREAD)
@@ -660,6 +662,7 @@ public:
 		,_regionLocalFree(NULL)
 		,_regionLocalFull(NULL)
 #endif /* OMR_GC_SEGREGATED_HEAP */
+		,_deferredScanDepth(0)
 		,_objectAllocationInterface(NULL)
 		,_workStack()
 		,_threadType(MUTATOR_THREAD)

--- a/gc/base/EnvironmentBase.hpp
+++ b/gc/base/EnvironmentBase.hpp
@@ -114,6 +114,18 @@ protected:
 
 public:
 	uintptr_t _deferredScanDepth;
+	uintptr_t _numberCopyCachesCreated;
+	uintptr_t _aliasAttempt;
+	
+	uintptr_t _releaseAll;
+	uintptr_t _overflowStack;
+	
+	uintptr_t _totalPushed;
+	uintptr_t _totalPoped;
+	uintptr_t _totalReleased;
+	uintptr_t _maxStack;
+		
+
 	/**
 	 * Codes used to identify attached VM threads.
 	 *
@@ -614,6 +626,14 @@ public:
 		,_regionLocalFull(NULL)
 #endif /* OMR_GC_SEGREGATED_HEAP */
 		,_deferredScanDepth(0)
+		,_numberCopyCachesCreated(0)
+		,_aliasAttempt(0)
+		,_releaseAll(0)
+		,_overflowStack(0)
+		,_totalPushed(0)
+		,_totalPoped(0)
+		,_totalReleased(0)
+		,_maxStack(0)
 		,_objectAllocationInterface(NULL)
 		,_workStack()
 		,_threadType(MUTATOR_THREAD)
@@ -663,6 +683,14 @@ public:
 		,_regionLocalFull(NULL)
 #endif /* OMR_GC_SEGREGATED_HEAP */
 		,_deferredScanDepth(0)
+		,_numberCopyCachesCreated(0)
+		,_aliasAttempt(0)
+		,_releaseAll(0)
+		,_overflowStack(0)
+		,_totalPushed(0)
+		,_totalPoped(0)
+		,_totalReleased(0)
+		,_maxStack(0)
 		,_objectAllocationInterface(NULL)
 		,_workStack()
 		,_threadType(MUTATOR_THREAD)

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -402,6 +402,7 @@ public:
 	};
 	ScavengerScanOrdering scavengerScanOrdering; /**< scan ordering in Scavenger */
 #if defined(OMR_GC_MODRON_SCAVENGER)
+	uintptr_t deferMaxDepth;
 	uintptr_t scvTenureRatioHigh;
 	uintptr_t scvTenureRatioLow;
 	uintptr_t scvTenureFixedTenureAge; /**< The tenure age to use for the Fixed scavenger tenure strategy. */
@@ -1338,6 +1339,7 @@ public:
 		, scavengerScanOrdering(OMR_GC_SCAVENGER_SCANORDERING_HIERARCHICAL)
 #endif /* OMR_GC_MODRON_SCAVENGER || OMR_GC_VLHGC */
 #if defined(OMR_GC_MODRON_SCAVENGER)
+		, deferMaxDepth(2)
 		, scvTenureRatioHigh(J9_SCV_TENURE_RATIO_HIGH)
 		, scvTenureRatioLow(J9_SCV_TENURE_RATIO_LOW)
 		, scvTenureFixedTenureAge(OBJECT_HEADER_AGE_MAX)

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -1339,7 +1339,7 @@ public:
 		, scavengerScanOrdering(OMR_GC_SCAVENGER_SCANORDERING_HIERARCHICAL)
 #endif /* OMR_GC_MODRON_SCAVENGER || OMR_GC_VLHGC */
 #if defined(OMR_GC_MODRON_SCAVENGER)
-		, deferMaxDepth(2000)
+		, deferMaxDepth(12)
 		, scvTenureRatioHigh(J9_SCV_TENURE_RATIO_HIGH)
 		, scvTenureRatioLow(J9_SCV_TENURE_RATIO_LOW)
 		, scvTenureFixedTenureAge(OBJECT_HEADER_AGE_MAX)

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -1339,7 +1339,7 @@ public:
 		, scavengerScanOrdering(OMR_GC_SCAVENGER_SCANORDERING_HIERARCHICAL)
 #endif /* OMR_GC_MODRON_SCAVENGER || OMR_GC_VLHGC */
 #if defined(OMR_GC_MODRON_SCAVENGER)
-		, deferMaxDepth(4)
+		, deferMaxDepth(2000)
 		, scvTenureRatioHigh(J9_SCV_TENURE_RATIO_HIGH)
 		, scvTenureRatioLow(J9_SCV_TENURE_RATIO_LOW)
 		, scvTenureFixedTenureAge(OBJECT_HEADER_AGE_MAX)

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -1339,7 +1339,7 @@ public:
 		, scavengerScanOrdering(OMR_GC_SCAVENGER_SCANORDERING_HIERARCHICAL)
 #endif /* OMR_GC_MODRON_SCAVENGER || OMR_GC_VLHGC */
 #if defined(OMR_GC_MODRON_SCAVENGER)
-		, deferMaxDepth(2)
+		, deferMaxDepth(4)
 		, scvTenureRatioHigh(J9_SCV_TENURE_RATIO_HIGH)
 		, scvTenureRatioLow(J9_SCV_TENURE_RATIO_LOW)
 		, scvTenureFixedTenureAge(OBJECT_HEADER_AGE_MAX)

--- a/gc/base/standard/EnvironmentStandard.hpp
+++ b/gc/base/standard/EnvironmentStandard.hpp
@@ -62,6 +62,8 @@ public:
 	void *_survivorTLHRemainderBase; /**< base and top pointers of the last unused survivor TLH copy cache, that might be reused  on next copy refresh */
 	void *_survivorTLHRemainderTop;
 
+	uintptr_t _deferredScanDepth;
+
 protected:
 
 private:
@@ -95,6 +97,7 @@ public:
 		,_loaAllocation(false)
 		,_survivorTLHRemainderBase(NULL)
 		,_survivorTLHRemainderTop(NULL)
+		,_deferredScanDepth(0)
 	{
 		_typeId = __FUNCTION__;
 	}

--- a/gc/base/standard/EnvironmentStandard.hpp
+++ b/gc/base/standard/EnvironmentStandard.hpp
@@ -63,6 +63,10 @@ public:
 	void *_survivorTLHRemainderTop;
 
 	
+	MM_CopyScanCacheStandard **_deferredStack;
+	int _stackTop;
+	int _stackBottom;
+
 	uintptr_t _maxDeferred;
 	
 protected:
@@ -98,6 +102,9 @@ public:
 		,_loaAllocation(false)
 		,_survivorTLHRemainderBase(NULL)
 		,_survivorTLHRemainderTop(NULL)
+		,_deferredStack(NULL)
+		,_stackTop(0)
+		,_stackBottom(0)
 		,_maxDeferred(0)
 	{
 		_typeId = __FUNCTION__;

--- a/gc/base/standard/EnvironmentStandard.hpp
+++ b/gc/base/standard/EnvironmentStandard.hpp
@@ -62,7 +62,7 @@ public:
 	void *_survivorTLHRemainderBase; /**< base and top pointers of the last unused survivor TLH copy cache, that might be reused  on next copy refresh */
 	void *_survivorTLHRemainderTop;
 
-	uintptr_t _deferredScanDepth;
+	
 	uintptr_t _maxDeferred;
 	
 protected:
@@ -98,7 +98,6 @@ public:
 		,_loaAllocation(false)
 		,_survivorTLHRemainderBase(NULL)
 		,_survivorTLHRemainderTop(NULL)
-		,_deferredScanDepth(0)
 		,_maxDeferred(0)
 	{
 		_typeId = __FUNCTION__;

--- a/gc/base/standard/EnvironmentStandard.hpp
+++ b/gc/base/standard/EnvironmentStandard.hpp
@@ -63,7 +63,8 @@ public:
 	void *_survivorTLHRemainderTop;
 
 	uintptr_t _deferredScanDepth;
-
+	uintptr_t _maxDeferred;
+	
 protected:
 
 private:
@@ -98,6 +99,7 @@ public:
 		,_survivorTLHRemainderBase(NULL)
 		,_survivorTLHRemainderTop(NULL)
 		,_deferredScanDepth(0)
+		,_maxDeferred(0)
 	{
 		_typeId = __FUNCTION__;
 	}

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -422,6 +422,7 @@ void
 MM_Scavenger::workerSetupForGC(MM_EnvironmentStandard *env)
 {
 	clearThreadGCStats(env, true);
+	env->_maxDeferred = 0;
 
 	/* Clear local language-specific stats */
 	_cli->scavenger_workerSetupForGC_clearEnvironmentLangStats(env);
@@ -1598,7 +1599,7 @@ MM_Scavenger::updateCopyScanCounts(MM_EnvironmentBase* env, uint64_t slotsScanne
 	env->_scavengerStats._slotsCopied += slotsCopied;
 	uint64_t updateResult = _extensions->copyScanRatio.update(env, &(env->_scavengerStats._slotsScanned), &(env->_scavengerStats._slotsCopied), _waitingCount);
 	if (0 != updateResult) {
-		_extensions->copyScanRatio.majorUpdate(env, updateResult, _cachedEntryCount, _scavengeCacheScanList.getApproximateEntryCount());
+		_extensions->copyScanRatio.majorUpdate(env, updateResult, _cachedEntryCount, _scavengeCacheScanList.getApproximateEntryCount(), env->_deferredScanDepth);
 	}
 }
 

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -300,12 +300,12 @@ MM_Scavenger::tearDown(MM_EnvironmentBase *env)
 		_freeCacheMonitor = NULL;
 	}
 
-	MM_EnvironmentStandard *envStandard = MM_EnvironmentStandard::getEnvironment(env);
+//	MM_EnvironmentStandard *envStandard = MM_EnvironmentStandard::getEnvironment(env);
 
-	if (NULL != envStandard->_deferredStack) {
-		envStandard->getForge()->free(envStandard->_deferredStack);
-		envStandard->_deferredStack = NULL;
-	}
+//	if (NULL != envStandard->_deferredStack) {
+//		envStandard->getForge()->free(envStandard->_deferredStack);
+//		envStandard->_deferredStack = NULL;
+//	}
 
 	J9HookInterface** mmOmrHooks = J9_HOOK_INTERFACE(_extensions->omrHookInterface);
 	/* Unregister hook for global GC end. */
@@ -1833,16 +1833,16 @@ MM_Scavenger::getNextScanCache(MM_EnvironmentStandard *env)
 	cache = env->_deferredScanCache;
 	if (NULL != cache) {
 		/* there is deferred scanning to do from partial depth first scanning */
-		OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
+		//OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
 
-		Assert_MM_true(env->_deferredStack[env->_stackTop] == env->_deferredScanCache);
-		Assert_MM_true(env->_stackTop >= 0 && env->_stackBottom >= 0);
+		//Assert_MM_true(env->_deferredStack[env->_stackTop] == env->_deferredScanCache);
+		//Assert_MM_true(env->_stackTop >= 0 && env->_stackBottom >= 0);
 
-		if(env->_stackTop == env->_stackBottom)
-			Assert_MM_true(env->_deferredScanDepth == 1);
+		//if(env->_stackTop == env->_stackBottom)
+		//	Assert_MM_true(env->_deferredScanDepth == 1);
 
-		if(env->_deferredScanDepth == 1)
-			Assert_MM_true(env->_stackTop == env->_stackBottom);
+		//if(env->_deferredScanDepth == 1)
+		//	Assert_MM_true(env->_stackTop == env->_stackBottom);
 
 		env->_deferredScanDepth--;
 
@@ -1851,39 +1851,39 @@ MM_Scavenger::getNextScanCache(MM_EnvironmentStandard *env)
 			env->_stackTop = env->_stackBottom = -1;
 			env->_deferredScanCache = NULL;
 		} else{
-			bool print = false;
+		//	bool print = false;
 			env->_deferredStack[env->_stackTop] = NULL;
 
-			if(env->_stackTop == 0 && printStatements){
-				omrtty_printf("{SCAV: BEFORE stackTop is %i]}\n", env->_stackTop);
-				print = true;
-			}
+		//	if(env->_stackTop == 0 && printStatements){
+		//		omrtty_printf("{SCAV: BEFORE stackTop is %i]}\n", env->_stackTop);
+		//		print = true;
+		//	}
 
 			env->_stackTop =  env->_stackTop > 0 ? --env->_stackTop :  _extensions->deferMaxDepth - 1;
 
 
-			if(print)
-				omrtty_printf("{SCAV: AFTER stackTop is %i]}\n", env->_stackTop);
+		//	if(print)
+		//		omrtty_printf("{SCAV: AFTER stackTop is %i]}\n", env->_stackTop);
 
-			if(printStatements) omrtty_printf("{SCAV: Depth != 0 - Defer Cache [_deferredScanDepth: %i, _scanTop %i _scanBottom %i]}\n", env->_deferredScanDepth, env->_stackTop, env->_stackBottom);
+		//	if(printStatements) omrtty_printf("{SCAV: Depth != 0 - Defer Cache [_deferredScanDepth: %i, _scanTop %i _scanBottom %i]}\n", env->_deferredScanDepth, env->_stackTop, env->_stackBottom);
 
-			Assert_MM_true(env->_deferredStack[env->_stackTop] != NULL);
+		//	Assert_MM_true(env->_deferredStack[env->_stackTop] != NULL);
 			env->_deferredScanCache =  env->_deferredStack[env->_stackTop];
-			Assert_MM_true(env->_deferredScanCache != NULL);
+		//	Assert_MM_true(env->_deferredScanCache != NULL);
 		}
 
-		if(env->_deferredScanDepth == 1)
-			Assert_MM_true(env->_stackTop == env->_stackBottom);
+		//if(env->_deferredScanDepth == 1)
+		//	Assert_MM_true(env->_stackTop == env->_stackBottom);
 
-		if(printStatements)omrtty_printf("{SCAV: POP Defer Cache [_deferredScanDepth: %i, _scanTop %i _scanBottom %i]}\n", env->_deferredScanDepth, env->_stackTop, env->_stackBottom);
+		//if(printStatements)omrtty_printf("{SCAV: POP Defer Cache [_deferredScanDepth: %i, _scanTop %i _scanBottom %i]}\n", env->_deferredScanDepth, env->_stackTop, env->_stackBottom);
 
-		Assert_MM_true(env->_deferredScanDepth >= 0);
+		//Assert_MM_true(env->_deferredScanDepth >= 0);
 
 		return cache;
 	}
-	else{
-		Assert_MM_true((env->_deferredScanDepth == 0) && (env->_stackTop == -1) && (env->_stackBottom == -1));
-	}
+	//else{
+		//Assert_MM_true((env->_deferredScanDepth == 0) && (env->_stackTop == -1) && (env->_stackBottom == -1));
+	//}
 
 	cache = env->_deferredCopyCache;
 	if (NULL != cache) {
@@ -2063,9 +2063,9 @@ nextCache:
 				 */
 				scanCache->flags &= ~OMR_SCAVENGER_CACHE_TYPE_SCAN;
 				if (!(scanCache->flags & OMR_SCAVENGER_CACHE_TYPE_COPY)) {
-					OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
+					//OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
 					if (env->_deferredScanDepth < _extensions->deferMaxDepth) {
-						if(printStatements)omrtty_printf("{SCAV: env->_deferredScanDepth = %i < %i - call deferScan}\n", env->_deferredScanDepth, _extensions->deferMaxDepth);
+						//if(printStatements)omrtty_printf("{SCAV: env->_deferredScanDepth = %i < %i - call deferScan}\n", env->_deferredScanDepth, _extensions->deferMaxDepth);
 						deferScan(env, scanCache);
 					} else {
 						/* Our stack is full, release the tail of the defer stack to global Q
@@ -2075,7 +2075,7 @@ nextCache:
 						env->_scavengerStats._releaseScanListCount += 1;
 #endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
 						MM_CopyScanCacheStandard *lastCache = popLastDeferCache(env);
-						Assert_MM_true(lastCache != NULL);
+						//Assert_MM_true(lastCache != NULL);
 						addCacheEntryToScanListAndNotify(env, lastCache);
 						deferScan(env, scanCache);
 					}
@@ -2099,13 +2099,13 @@ nextCache:
 MM_CopyScanCacheStandard*
 MM_Scavenger::popLastDeferCache(MM_EnvironmentStandard *env){
 
-	Assert_MM_true(env->_stackBottom >= 0);
+	//Assert_MM_true(env->_stackBottom >= 0);
 
-	Assert_MM_true(env->_deferredStack[env->_stackTop] != NULL);
-	Assert_MM_true(env->_deferredStack[env->_stackBottom] != NULL);
+	//Assert_MM_true(env->_deferredStack[env->_stackTop] != NULL);
+	//Assert_MM_true(env->_deferredStack[env->_stackBottom] != NULL);
 
-	if(env->_deferredScanDepth == 1)
-		Assert_MM_true(env->_deferredStack[env->_stackBottom] == env->_deferredStack[env->_stackTop]);
+	//if(env->_deferredScanDepth == 1)
+	//	Assert_MM_true(env->_deferredStack[env->_stackBottom] == env->_deferredStack[env->_stackTop]);
 
 	MM_CopyScanCacheStandard *lastDeferCache = env->_deferredStack[env->_stackBottom];
 	env->_deferredStack[env->_stackBottom] = NULL;
@@ -2114,14 +2114,14 @@ MM_Scavenger::popLastDeferCache(MM_EnvironmentStandard *env){
 
 	env->_deferredScanDepth--;
 
-	if(env->_deferredScanDepth == 1)
-		Assert_MM_true(env->_stackBottom == env->_stackTop);
+	//if(env->_deferredScanDepth == 1)
+	//	Assert_MM_true(env->_stackBottom == env->_stackTop);
 
 	if(env->_deferredScanDepth == 0){
 		env->_stackBottom  = env->_stackTop = -1;
 		env->_deferredScanCache = NULL;
-	}else
-		Assert_MM_true(env->_deferredStack[env->_stackTop] == env->_deferredScanCache);
+	}//else
+		//Assert_MM_true(env->_deferredStack[env->_stackTop] == env->_deferredScanCache);
 
 
 
@@ -2130,74 +2130,69 @@ MM_Scavenger::popLastDeferCache(MM_EnvironmentStandard *env){
 
 void
 MM_Scavenger::deferScan(MM_EnvironmentStandard *env, MM_CopyScanCacheStandard *newDeferEntry){
-	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
+	//OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
 
-	Assert_MM_true(env->_deferredScanDepth < _extensions->deferMaxDepth);
+	//Assert_MM_true(env->_deferredScanDepth < _extensions->deferMaxDepth);
 
 	env->_deferredScanDepth++;
 
-	if(env->_deferredScanDepth > env->_maxDeferred){
-		 env->_maxDeferred = env->_deferredScanDepth;
-		 if(printStatements) omrtty_printf("{SCAV: NEW MAX IS SET: %i}\n", env->_maxDeferred);
-	}
-
-	if(env->_stackTop >= 0) Assert_MM_true(env->_deferredStack[env->_stackTop] != NULL);
+//	if(env->_stackTop >= 0) Assert_MM_true(env->_deferredStack[env->_stackTop] != NULL);
 	env->_stackTop =  ++env->_stackTop % _extensions->deferMaxDepth;
-	Assert_MM_true(env->_stackTop != env->_stackBottom);
-	Assert_MM_true(env->_deferredStack[env->_stackTop] == NULL);
+//	Assert_MM_true(env->_stackTop != env->_stackBottom);
+//	Assert_MM_true(env->_deferredStack[env->_stackTop] == NULL);
 
 	env->_deferredStack[env->_stackTop] = newDeferEntry;
 	env->_deferredScanCache = env->_deferredStack[env->_stackTop];
 
 	if(env->_stackBottom == -1){ //we're pushing the first defer scan (i.e., the stack was empty)
 		env->_stackBottom = env->_stackTop;
-		Assert_MM_true(env->_stackBottom == 0);
-		Assert_MM_true(env->_stackTop == 0);
-		Assert_MM_true(env->_deferredScanDepth == 1);
+//		Assert_MM_true(env->_stackBottom == 0);
+//		Assert_MM_true(env->_stackTop == 0);
+//		Assert_MM_true(env->_deferredScanDepth == 1);
 	}
 
-	if(env->_deferredScanDepth == 1) Assert_MM_true((env->_stackBottom == 0) && (env->_stackTop == 0));
+//	if(env->_deferredScanDepth == 1) Assert_MM_true((env->_stackBottom == 0) && (env->_stackTop == 0));
 
-	if(printStatements) omrtty_printf("{SCAV: _stackTop: %i, _stackBottom: %i}\n", env->_stackTop, env->_stackBottom);
+//	if(printStatements) omrtty_printf("{SCAV: _stackTop: %i, _stackBottom: %i}\n", env->_stackTop, env->_stackBottom);
 
 }
 
 void
 MM_Scavenger::releaseDeferCaches(MM_EnvironmentStandard *env){
 
-	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
+	//OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
 
-	Assert_MM_true(env->_deferredScanCache != NULL);
-	Assert_MM_true(env->_deferredScanDepth > 0);
-	Assert_MM_true(env->_deferredScanCache == env->_deferredStack[env->_stackTop]);
+	//Assert_MM_true(env->_deferredScanCache != NULL);
+	//Assert_MM_true(env->_deferredScanDepth > 0);
+	//Assert_MM_true(env->_deferredScanCache == env->_deferredStack[env->_stackTop]);
 
-	if(env->_deferredScanDepth == 1)
-			Assert_MM_true(env->_stackTop == env->_stackBottom);
+	//if(env->_deferredScanDepth == 1)
+	//		Assert_MM_true(env->_stackTop == env->_stackBottom);
 
 	uintptr_t temp = env->_deferredScanDepth;
 	for (uintptr_t count = 0; count < temp; count++) {
 		env->_deferredScanDepth--;
-		if(printStatements)omrtty_printf("{SCAV: releaseDeferCaches [_deferredScanDepth: %i]}\n", env->_deferredScanDepth);
-		Assert_MM_true(env->_deferredStack[env->_stackTop] != NULL);
+		//if(printStatements)omrtty_printf("{SCAV: releaseDeferCaches [_deferredScanDepth: %i]}\n", env->_deferredScanDepth);
+		//Assert_MM_true(env->_deferredStack[env->_stackTop] != NULL);
 		addCacheEntryToScanListAndNotify(env, env->_deferredStack[env->_stackTop]);
 		env->_deferredStack[env->_stackTop] = NULL;
 
-		if(env->_deferredScanDepth == 0)
-				Assert_MM_true(env->_stackTop == env->_stackBottom);
+		//if(env->_deferredScanDepth == 0)
+		//		Assert_MM_true(env->_stackTop == env->_stackBottom);
 
-		bool print = false;
-		if(env->_stackTop == 0 && printStatements){
-			omrtty_printf("{SCAV: BEFORE stackTop is %i]}\n", env->_stackTop);
-			print = true;
-		}
+		//bool print = false;
+		//if(env->_stackTop == 0 && printStatements){
+		//	omrtty_printf("{SCAV: BEFORE stackTop is %i]}\n", env->_stackTop);
+		//	print = true;
+		//}
 
 		env->_stackTop =  env->_stackTop > 0 ? --env->_stackTop :  _extensions->deferMaxDepth - 1;
 
-		if(print)
-			omrtty_printf("{SCAV: AFTER stackTop is %i]}\n", env->_stackTop);
+		//if(print)
+		//	omrtty_printf("{SCAV: AFTER stackTop is %i]}\n", env->_stackTop);
 
-		if(env->_deferredScanDepth == 1)
-			Assert_MM_true(env->_stackTop == env->_stackBottom);
+		//if(env->_deferredScanDepth == 1)
+		//	Assert_MM_true(env->_stackTop == env->_stackBottom);
 
 #if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
 		env->_scavengerStats._releaseScanListCount += 1;
@@ -2207,7 +2202,7 @@ MM_Scavenger::releaseDeferCaches(MM_EnvironmentStandard *env){
 	env->_stackTop = env->_stackBottom = -1;
 	env->_deferredScanCache = NULL;
 
-	Assert_MM_true(env->_deferredScanDepth == 0);
+	//Assert_MM_true(env->_deferredScanDepth == 0);
 }
 
 bool
@@ -3307,13 +3302,39 @@ MM_Scavenger::aliasToCopyCache(MM_EnvironmentStandard *env, GC_SlotObject *scann
 	 *
 	 * @NOTE this is likely too aggressive and should be relaxed.
 	 */
+
+
+	MM_CopyScanCacheStandard *newCache = NULL;
+
 	if (0 == _waitingCount) {
 		/* Only alias if the scanCache != copyCache. IF the caches are the same there is no benefit
 		 * to aliasing. The checks afterwards will ensure that a very similar copy order will happen
 		 * if the copyCache changes from the currently aliased scan cache
 		 *
 		 * Perform this check first since these values are likely in the threads L1 cache */
+
+		// 4kB between scan pointer nad alloc pointer of the scan
 		if (scanCache == copyCache) {
+			if((uintptr_t)copyCache->cacheAlloc - (uintptr_t)copyCache->scanCurrent > 4000 ){
+				newCache = getFreeCache(env);
+
+				Assert_MM_true(newCache != NULL);
+
+				reinitCache(newCache, copyCache->cacheAlloc, copyCache->cacheTop);
+
+				copyCache->flags &= ~OMR_SCAVENGER_CACHE_TYPE_COPY;
+				copyCache->cacheTop = copyCache->cacheAlloc;
+
+				if (copyCache->flags & OMR_SCAVENGER_CACHE_TYPE_SEMISPACE) {
+					env->_survivorCopyScanCache = newCache;
+					env->_survivorCopyScanCache->flags = OMR_SCAVENGER_CACHE_TYPE_SEMISPACE | OMR_SCAVENGER_CACHE_TYPE_COPY;
+				} else if (copyCache->flags & OMR_SCAVENGER_CACHE_TYPE_TENURESPACE) {
+					env->_tenureCopyScanCache = newCache;
+					env->_tenureCopyScanCache->flags = OMR_SCAVENGER_CACHE_TYPE_TENURESPACE | OMR_SCAVENGER_CACHE_TYPE_COPY;
+				} else{
+					Assert_MM_unreachable();
+				}
+			}
 			return NULL;
 		}
 

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -292,6 +292,9 @@ public:
 	
 	MMINLINE void deferScan(MM_EnvironmentStandard *env, MM_CopyScanCacheStandard *deferEntry);
 	MMINLINE void releaseDeferCaches(MM_EnvironmentStandard *env);
+	MMINLINE MM_CopyScanCacheStandard* popLastDeferCache(MM_EnvironmentStandard *env);
+	MMINLINE MM_CopyScanCacheStandard* getLastDeferCache(MM_EnvironmentStandard *env);
+	
 	MMINLINE MM_CopyScanCacheStandard *aliasToCopyCache(MM_EnvironmentStandard *env, GC_SlotObject *scannedSlot, MM_CopyScanCacheStandard* scanCache, MM_CopyScanCacheStandard* copyCache);
 	MMINLINE uintptr_t scanCacheDistanceMetric(MM_CopyScanCacheStandard* cache, GC_SlotObject *scanSlot);
 	MMINLINE uintptr_t copyCacheDistanceMetric(MM_CopyScanCacheStandard* cache);

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -289,7 +289,9 @@ public:
 
 	void completeScanCache(MM_EnvironmentStandard *env, MM_CopyScanCacheStandard* scanCache);
 	void incrementalScanCacheBySlot(MM_EnvironmentStandard *env, MM_CopyScanCacheStandard* scanCache);
-
+	
+	MMINLINE void deferScan(MM_EnvironmentStandard *env, MM_CopyScanCacheStandard *deferEntry);
+	MMINLINE void releaseDeferCaches(MM_EnvironmentStandard *env);
 	MMINLINE MM_CopyScanCacheStandard *aliasToCopyCache(MM_EnvironmentStandard *env, GC_SlotObject *scannedSlot, MM_CopyScanCacheStandard* scanCache, MM_CopyScanCacheStandard* copyCache);
 	MMINLINE uintptr_t scanCacheDistanceMetric(MM_CopyScanCacheStandard* cache, GC_SlotObject *scanSlot);
 	MMINLINE uintptr_t copyCacheDistanceMetric(MM_CopyScanCacheStandard* cache);

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -293,7 +293,6 @@ public:
 	MMINLINE void deferScan(MM_EnvironmentStandard *env, MM_CopyScanCacheStandard *deferEntry);
 	MMINLINE void releaseDeferCaches(MM_EnvironmentStandard *env);
 	MMINLINE MM_CopyScanCacheStandard* popLastDeferCache(MM_EnvironmentStandard *env);
-	MMINLINE MM_CopyScanCacheStandard* getLastDeferCache(MM_EnvironmentStandard *env);
 	
 	MMINLINE MM_CopyScanCacheStandard *aliasToCopyCache(MM_EnvironmentStandard *env, GC_SlotObject *scannedSlot, MM_CopyScanCacheStandard* scanCache, MM_CopyScanCacheStandard* copyCache);
 	MMINLINE uintptr_t scanCacheDistanceMetric(MM_CopyScanCacheStandard* cache, GC_SlotObject *scanSlot);

--- a/gc/stats/ScavengerCopyScanRatio.cpp
+++ b/gc/stats/ScavengerCopyScanRatio.cpp
@@ -47,7 +47,7 @@ MM_ScavengerCopyScanRatio::reset(MM_EnvironmentBase* env, bool resetHistory)
 }
 
 uintptr_t
-MM_ScavengerCopyScanRatio::record(MM_EnvironmentBase* env, uintptr_t nonEmptyScanLists, uintptr_t cachesQueued)
+MM_ScavengerCopyScanRatio::record(MM_EnvironmentBase* env, uintptr_t nonEmptyScanLists, uintptr_t cachesQueued, uintptr_t deferDepth)
 {
 	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
 	if (SCAVENGER_UPDATE_HISTORY_SIZE <= _historyTableIndex) {
@@ -65,6 +65,7 @@ MM_ScavengerCopyScanRatio::record(MM_EnvironmentBase* env, uintptr_t nonEmptySca
 			prev->threads += tail->threads;
 			prev->lists += tail->lists;
 			prev->caches += tail->caches;
+			prev->deferDepth += tail->deferDepth;
 			prev->time = tail->time;
 			if (prev > head) {
 				memcpy(head, prev, sizeof(UpdateHistory));
@@ -89,6 +90,7 @@ MM_ScavengerCopyScanRatio::record(MM_EnvironmentBase* env, uintptr_t nonEmptySca
 	historyRecord->threads += threadCount;
 	historyRecord->lists += nonEmptyScanLists;
 	historyRecord->caches += cachesQueued;
+	historyRecord->deferDepth += deferDepth;
 	historyRecord->time = omrtime_hires_clock();
 
 	/* advance table index if current record is maxed out */

--- a/gc/stats/ScavengerCopyScanRatio.hpp
+++ b/gc/stats/ScavengerCopyScanRatio.hpp
@@ -102,6 +102,7 @@ public:
 		uint64_t lists;		/* number of nonempty scan lists */
 		uint64_t caches;	/* number of caches in scan queues */
 		uint64_t time;		/* timestamp of most recent sample included in this record */
+		uint64_t deferDepth;		/* timestamp of most recent sample included in this record */
 	} UpdateHistory;
 
 
@@ -225,12 +226,12 @@ public:
 	 * @param cachesQueued total number of items in scan queue lists
 	 */
 	MMINLINE void 
-	majorUpdate(MM_EnvironmentBase* env, uint64_t updateResult, uintptr_t nonEmptyScanLists, uintptr_t cachesQueued) {
+	majorUpdate(MM_EnvironmentBase* env, uint64_t updateResult, uintptr_t nonEmptyScanLists, uintptr_t cachesQueued, uintptr_t deferDepth) {
 		if (0 == (SCAVENGER_COUNTER_OVERFLOW & updateResult)) {
 			/* no overflow so latch updateResult into _accumulatedSamples and record the update */
 			MM_AtomicOperations::setU64(&_accumulatedSamples, updateResult);
 			_scalingUpdateCount += 1;
-			_threadCount = record(env, nonEmptyScanLists, cachesQueued);
+			_threadCount = record(env, nonEmptyScanLists, cachesQueued, deferDepth);
 		} else {
 			/* one or more counters overflowed so discard this update */
 			_overflowCount += 1;
@@ -386,7 +387,7 @@ private:
 
 	MMINLINE uint64_t updates(uint64_t samples) { return samples & SCAVENGER_SLOTS_UPDATE_MASK; }
 
-	uintptr_t record(MM_EnvironmentBase* env, uintptr_t nonEmptyScanLists, uintptr_t cachesQueued);
+	uintptr_t record(MM_EnvironmentBase* env, uintptr_t nonEmptyScanLists, uintptr_t cachesQueued, uintptr_t deferDepth);
 
 	void failedUpdate(MM_EnvironmentBase* env, uint64_t copied, uint64_t scanned);
 };


### PR DESCRIPTION
This issue will be used to highlight and track the changes being made to Scavenger defer caching and aliasing. Furthermore, the impacts of such changes will be discussed and shared (e.g., benchmark results). The scope of this work includes defer-cache nesting and proactive cache aliasing with the goal of increasing locality by 

1) Decreasing the amount of scan work (defer caches) pushed to the global queue, whereby scan caches are bound to the a single CPU. Additionally, this decreases the contention on the global queue.
2) Proactively aliasing to increase object cache locality. 

### Defer-Cache Nesting
Currently, when an opportunity to alias to a copy cache arises, scanning is interrupted and the scan cache is saved/deferred for a later time on the same thread _(referenced by __deferredScanCache_ thread local env variable)_. However, **if the deferred cache is occupied _(i.e., already have a deferred cache)_, then the scan cache is pushed and queued onto the global scan queue**:

````c++
if (!(scanCache->flags & OMR_SCAVENGER_CACHE_TYPE_COPY)) {
	if (NULL == env->_deferredScanCache) {
		env->_deferredScanCache = scanCache;
	} else {
		addCacheEntryToScanListAndNotify(env, scanCache);
	}
}
````

This allows other threads to acquire the scan cache, consequently, locality is lost and contention on the global queue is increased. To mitigate this behaviour, the thread environment `_deferredScanCache` has been expanded into a stack _(implemented as a fixed sized array)_. With this change, the cache to be deferred is always kept local to the thread (pushed to a local stack rather than the global queue):

```diff
@@ -1995,13 +2063,21 @@ nextCache:
                                 */
                                scanCache->flags &= ~OMR_SCAVENGER_CACHE_TYPE_SCAN;
                                if (!(scanCache->flags & OMR_SCAVENGER_CACHE_TYPE_COPY)) {
-                                       if (NULL == env->_deferredScanCache) {
-                                               env->_deferredScanCache = scanCache;
+                                       if (env->_deferredScanDepth < _extensions->deferMaxDepth) {
+                                               deferScan(env, scanCache);
                                        } else {
+                                               /* Our stack is full, release the tail of the defer stack to global Q
+                                                * and push the scanCache onto the Defer Cache.
+                                                */
-                                               addCacheEntryToScanListAndNotify(env, scanCache);
+                                               MM_CopyScanCacheStandard *lastCache = popLastDeferCache(env);
+                                               addCacheEntryToScanListAndNotify(env, lastCache);
+                                               deferScan(env, scanCache);
                                        }
                                }

```


 Overall, this ensures that 
1) Same CPU will eventually pop the deferred scan cache off (locality benefits) and 
2) Less contention on the global queue

### Proactive Aliasing 
Proactive aliasing has been implemented to create opportunities for aliasing when aliasing is not possible, or in other words, to make aliasing more aggressive (i.e., increase the frequency of aliasing). This is done with the aim to increase locality by attempting to copy related objects to the same cache line.

Currently, we can only defer and alias if the copy cache (to be aliased to) is distinct from the scan cache. That is, scanned copy-scan hybrid caches will never be aliased. The criteria to alias is outlined by the following code _(note the case where scanCache == copyCache)_:
```c++ 
MM_Scavenger::aliasToCopyCache

if (scanCache == copyCache) {
	return NULL;
}

/* If the scanCache is not an aliased copy cache try to alias to the copy cache since the copy cache will always
 * be better if it has objects to scan */
if (0 == (scanCache->flags & OMR_SCAVENGER_CACHE_TYPE_COPY)) {
	if (copyCache->cacheAlloc != copyCache->scanCurrent) {
		env->_scavengerStats._aliasToCopyCacheCount += 1;
		scanCache->_hasPartiallyScannedObject = true;
		return copyCache;
	}
}

/* alias and switch to copy cache if it has scan work available and a shorter copy distance */
if (copyCacheDistanceMetric(copyCache) < scanCacheDistanceMetric(scanCache, scannedSlot)) {
	if (copyCache->cacheAlloc != copyCache->scanCurrent) {
		env->_scavengerStats._aliasToCopyCacheCount += 1;
		scanCache->_hasPartiallyScannedObject = true;
		return copyCache;
	}
}
```
**With proactive aliasing, we attempt to split hybrid copy-scan caches based on the distance from the start to the end of the unscanned work _(from scanCurrent to cacheAlloc)_.** If this distance is determined to be larger than a present threshold (currently 4K), then we proceed to split the copy-scan cache into a pure copy and a pure scan cache as follows: 
1. Create new copy cache starting from the copy-scan cache alloc pointer up-to the copy-scan cache top pointer.
2. Designate the scan cache starting from the  copy-scan cache base pointer up-to copy-scan cache alloc pointer.

![untitled diagram 6](https://user-images.githubusercontent.com/9648788/44807641-11fd6d00-ab98-11e8-8970-3565ed726172.png)


```diff
+               // 4kB between scan pointer and alloc pointer
                if (scanCache == copyCache) {
+                       if((uintptr_t)copyCache->cacheAlloc - (uintptr_t)copyCache->scanCurrent > 4000 ){
+                               newCache = getFreeCache(env);
+
+                               Assert_MM_true(newCache != NULL);
+
+                               reinitCache(newCache, copyCache->cacheAlloc, copyCache->cacheTop);
+
+                               copyCache->flags &= ~OMR_SCAVENGER_CACHE_TYPE_COPY;
+                               copyCache->cacheTop = copyCache->cacheAlloc;
+
+                               if (copyCache->flags & OMR_SCAVENGER_CACHE_TYPE_SEMISPACE) {
+                                       env->_survivorCopyScanCache = newCache;
+                                       env->_survivorCopyScanCache->flags = OMR_SCAVENGER_CACHE_TYPE_SEMISPACE | OMR_SCAVENGER_CACHE_TYPE_COPY;
+                               } else if (copyCache->flags & OMR_SCAVENGER_CACHE_TYPE_TENURESPACE) {
+                                       env->_tenureCopyScanCache = newCache;
+                                       env->_tenureCopyScanCache->flags = OMR_SCAVENGER_CACHE_TYPE_TENURESPACE | OMR_SCAVENGER_CACHE_TYPE_COPY;
+                               } else{
+                                       Assert_MM_unreachable();
+                               }
+                       }
                        return NULL;
                }
```

In this manner, the next copy forward will be to the new copy cache, and rather than proceeding to scan the next object in the scan cache, we will defer the scan cache and move to the copy cache and start scanning it _(i.e., scan the object that was just copied)_. The copy cache will now be designated as a hybrid  copy-scan cache. Consequently, locality will be increased as related objects will be copied adjacently in the newly created copy cache. Without proactive aliasing, we would either have related objects copied to separate caches or have related objects copied with larger distances between them.

![untitled diagram 3](https://user-images.githubusercontent.com/9648788/44800852-76630100-ab85-11e8-81cd-75ef7a42c9a2.png)

#### Alternative to Proactive Aliasing
Another alternative to this would be to simply create smaller size caches (e.g, 4K). However, this is not a viable solution as it would lead to fragmentation and unnecessarily use up cache structures and resources (popping free caches from the free the list and pushing to the scan list). With proactive aliasing, we ensure that we create a copy cache when its beneficial (threshold check), and we avoid fragmentation by splitting contagious memory.  
