### PR TITLE
Investigate Scavenger's Aliasing Inhibiting Condition

### DIFF
--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -4544,7 +4544,6 @@ MM_Scavenger::calculateTenureMaskUsingLookback(double minimumSurvivalRate, MM_En
 
 		if (requiredLookback >= age) {
 			/* this generation is too young to have enough history to satisfy the lookback */
-			omrtty_printf("{\t \t PRINT [LookBack]: SHOULD TENURE = FALSE \t (requiredLookback >= age) \n");
 			shouldTenureThisAge = false;
 		} else {
 			omrtty_printf("{\t \t PRINT [LookBack]: ELSE ...requiredLookback < age \n");

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -405,7 +405,7 @@ MM_Scavenger::masterSetupForGC(MM_EnvironmentStandard *env)
 	scavengerStats->_semiSpaceAllocBytesAcumulation += heapStatsSemiSpace._allocBytes;
 
 	/* Record the tenure mask */
-	_tenureMask = calculateTenureMask();
+	_tenureMask = calculateTenureMask(env);
 	
 	_activeSubSpace->masterSetupForGC(env);
 
@@ -745,9 +745,13 @@ MM_Scavenger::mergeIncrementGCStats(MM_EnvironmentBase *env, bool lastIncrement)
 	MM_ScavengerStats *finalGCStats = &_extensions->scavengerStats;
 	mergeGCStatsBase(env, finalGCStats, &_extensions->incrementScavengerStats);
 
+	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
+	omrtty_printf("{PRINT [mergeIncrementGCStats]: Entry}\n");
+
 	/* Language specific stats were supposed to be merged directly from thread local to cycle global. No need to merge them here. */
 
 	if (lastIncrement) {
+		omrtty_printf("{PRINT [mergeIncrementGCStats]: last increment}\n");
 		/* Calculate new tenure age */
 		finalGCStats->getFlipHistory(0)->_tenureMask = _tenureMask;
 		uintptr_t tenureAge = 0;
@@ -756,6 +760,8 @@ MM_Scavenger::mergeIncrementGCStats(MM_EnvironmentBase *env, bool lastIncrement)
 				break;
 			}
 		}
+
+		omrtty_printf("{PRINT [mergeIncrementGCStats]: _tenureAge %zu}\n", tenureAge);
 		finalGCStats->_tenureAge = tenureAge;
 
 		/* Update historical flip stats for age 0 */
@@ -3645,6 +3651,7 @@ void
 MM_Scavenger::masterThreadGarbageCollect(MM_EnvironmentBase *envBase, MM_AllocateDescription *allocDescription, bool initMarkMap, bool rebuildMarkBits)
 {
 	OMRPORT_ACCESS_FROM_OMRPORT(envBase->getPortLibrary());
+	omrtty_printf("{PRINT [masterThreadGarbageCollect]: Start }\n");
 	MM_EnvironmentStandard *env = MM_EnvironmentStandard::getEnvironment(envBase);
 	Trc_MM_Scavenger_masterThreadGarbageCollect_Entry(env->getLanguageVMThread());
 
@@ -3663,7 +3670,9 @@ MM_Scavenger::masterThreadGarbageCollect(MM_EnvironmentBase *envBase, MM_Allocat
 #endif
 
 	if (firstIncrement)	{
+		omrtty_printf("{PRINT [masterThreadGarbageCollect]: First Increment }\n");
 		if (_extensions->processLargeAllocateStats) {
+			omrtty_printf("{PRINT [masterThreadGarbageCollect]: ProcessLargeAllocateStatsBeforeGC }\n");
 			processLargeAllocateStatsBeforeGC(env);
 		}
 
@@ -3698,7 +3707,10 @@ MM_Scavenger::masterThreadGarbageCollect(MM_EnvironmentBase *envBase, MM_Allocat
 	mergeIncrementGCStats(env, lastIncrement);
 	reportScavengeEnd(env, lastIncrement);
 
+	omrtty_printf("{\t PRINT [masterThreadGarbageCollect]: bytesAllocated(%zu) }\n", (&_extensions->allocationStats)->bytesAllocated());
+
 	if (lastIncrement) {
+		omrtty_printf("{PRINT [masterThreadGarbageCollect]: Last Increment }\n");
 		/* defer to collector language interface */
 		_cli->scavenger_masterThreadGarbageCollect_scavengeComplete(env);
 
@@ -3710,6 +3722,7 @@ MM_Scavenger::masterThreadGarbageCollect(MM_EnvironmentBase *envBase, MM_Allocat
 		_extensions->scavengerStats._endTime = omrtime_hires_clock();
 
 		if(scavengeCompletedSuccessfully(env)) {
+			omrtty_printf("{PRINT [masterThreadGarbageCollect]: scavengeCompletedSuccessfully }\n");
 			/* Merge sublists in the remembered set (if necessary) */
 			_extensions->rememberedSet.compact(env);
 
@@ -3730,15 +3743,20 @@ MM_Scavenger::masterThreadGarbageCollect(MM_EnvironmentBase *envBase, MM_Allocat
 				uintptr_t newSpaceConsumedSize = _extensions->scavengerStats._flipBytes;
 				uintptr_t newSpaceSizeScale = newSpaceTotalSize / 100;
 
+				omrtty_printf("{PRINT [masterThreadGarbageCollect]: scvTenureAdaptiveTenureAge (%zu) newSpaceTotalSize (%zu) newSpaceConsumedSize (%zu) newSpaceSizeScale (%zu) bytesAllocated(%zu) _flipBytes (%zu) }\n", _extensions->scvTenureAdaptiveTenureAge, newSpaceTotalSize, newSpaceConsumedSize, newSpaceSizeScale, (&_extensions->allocationStats)->bytesAllocated(), _extensions->scavengerStats._flipBytes);
+
 				if((newSpaceConsumedSize < (_extensions->scvTenureRatioLow * newSpaceSizeScale)) && (_extensions->scvTenureAdaptiveTenureAge < OBJECT_HEADER_AGE_MAX)) {
 					_extensions->scvTenureAdaptiveTenureAge++;
+					omrtty_printf("{PRINT [masterThreadGarbageCollect]: scvTenureAdaptiveTenureAge++, new value (%zu)}\n", _extensions->scvTenureAdaptiveTenureAge);
 				} else {
 					if((newSpaceConsumedSize > (_extensions->scvTenureRatioHigh * newSpaceSizeScale)) && (_extensions->scvTenureAdaptiveTenureAge > OBJECT_HEADER_AGE_MIN)) {
 						_extensions->scvTenureAdaptiveTenureAge--;
+						omrtty_printf("{PRINT [masterThreadGarbageCollect]: scvTenureAdaptiveTenureAge-- new value (%zu)}\n", _extensions->scvTenureAdaptiveTenureAge);
 					}
 				}
 			}
 		} else {
+			omrtty_printf("{PRINT [masterThreadGarbageCollect]: scavengeCompletedSuccessfully == FASLE }\n");
 			/* Build free list in survivor profile - the scavenge was unsuccessful, so rebuild the free list */
 			_activeSubSpace->masterTeardownForAbortedGC(env);
 		}
@@ -3784,10 +3802,13 @@ MM_Scavenger::masterThreadGarbageCollect(MM_EnvironmentBase *envBase, MM_Allocat
 	if (lastIncrement) {
 		reportGCCycleEnd(env);
 		if (_extensions->processLargeAllocateStats) {
+			omrtty_printf("{PRINT [masterThreadGarbageCollect]: resetTenureLargeAllocateStats }\n");
 			/* reset tenure processLargeAllocateStats after TGC */
 			resetTenureLargeAllocateStats(env);
 		}
 	}
+
+	omrtty_printf("{\t PRINT [masterThreadGarbageCollect]: Clear Allocation Stats }\n");
 	_extensions->allocationStats.clear();
 
 	if (_extensions->trackMutatorThreadCategory) {
@@ -4395,31 +4416,49 @@ MM_Scavenger::reportGCIncrementEnd(MM_EnvironmentStandard *env)
 }
 
 uintptr_t
-MM_Scavenger::calculateTenureMask()
+MM_Scavenger::calculateTenureMask(MM_EnvironmentStandard *env)
 {
+	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
+
 	/* always tenure objects which have reached the maximum age */
 	uintptr_t newMask = ((uintptr_t)1 << OBJECT_HEADER_AGE_MAX);
 
+	omrtty_printf("{PRINT [calculateTenureMask]: Entry Mask %zu }\n", newMask);
+
 	/* Delegate tenure mask calculations to the active strategies. */
 	if (_extensions->scvTenureStrategyFixed) {
+		omrtty_printf("{PRINT [calculateTenureMask]: Fixed - Mask Before %zu }\n", newMask);
 		newMask |= calculateTenureMaskUsingFixed(_extensions->scvTenureFixedTenureAge);
+		omrtty_printf("{PRINT [calculateTenureMask]: Fixed - Mask After %zu }\n", newMask);
 	}
 	if (_extensions->scvTenureStrategyAdaptive) {
+		omrtty_printf("{PRINT [calculateTenureMask]: Adaptive - Mask Before %zu }\n", newMask);
 		newMask |= calculateTenureMaskUsingFixed(_extensions->scvTenureAdaptiveTenureAge);
+		omrtty_printf("{PRINT [calculateTenureMask]: Adaptive - Mask After %zu }\n", newMask);
 	}
 	if (_extensions->scvTenureStrategyLookback) {
-		newMask |= calculateTenureMaskUsingLookback(_extensions->scvTenureStrategySurvivalThreshold);
+		omrtty_printf("{PRINT [calculateTenureMask]: Lookback - Mask Before %zu }\n", newMask);
+		newMask |= calculateTenureMaskUsingLookback(_extensions->scvTenureStrategySurvivalThreshold, env);
+		omrtty_printf("{PRINT [calculateTenureMask]: Lookback - Mask After %zu }\n", newMask);
 	}
 	if (_extensions->scvTenureStrategyHistory) {
+		omrtty_printf("{PRINT [calculateTenureMask]: History - Mask Before %zu }\n", newMask);
 		newMask |= calculateTenureMaskUsingHistory(_extensions->scvTenureStrategySurvivalThreshold);
+		omrtty_printf("{PRINT [calculateTenureMask]: History - Mask After %zu }\n", newMask);
 	}
+
+	omrtty_printf("{PRINT [calculateTenureMask]: Exit Return Mask %zu }\n", newMask);
 
 	return newMask;
 }
 
 uintptr_t
-MM_Scavenger::calculateTenureMaskUsingLookback(double minimumSurvivalRate)
+MM_Scavenger::calculateTenureMaskUsingLookback(double minimumSurvivalRate, MM_EnvironmentStandard *env)
 {
+	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
+
+	omrtty_printf("{\n\n PRINT [LookBack]: LOOK Back Method Start }\n");
+
 	Assert_MM_true(0.0 <= minimumSurvivalRate);
 	Assert_MM_true(1.0 >= minimumSurvivalRate);
 
@@ -4461,16 +4500,22 @@ MM_Scavenger::calculateTenureMaskUsingLookback(double minimumSurvivalRate)
 		standardDeviationOfInitialGenerationSize = sqrt(accumulatedSquareDeltas / (double)count);
 	}
 
+	omrtty_printf("{\t PRINT [LookBack]: accumulatedGenerationSizes (%f) count (%zu) averageInitialGenerationSize (%f) accumulatedSquareDeltas (%f)  standardDeviationOfInitialGenerationSize (%f)}\n", accumulatedGenerationSizes, count, averageInitialGenerationSize, accumulatedSquareDeltas, standardDeviationOfInitialGenerationSize);
+
 	/* This normalized initial generation size (calculated using the standard
 	 * deviation) is used for determining how far back in history we should be looking.
 	 * The larger this is, the shallower we look back.
 	 */
 	uintptr_t normalizedInitialGenerationSize = (uintptr_t)OMR_MAX(0.0, averageInitialGenerationSize - standardDeviationOfInitialGenerationSize);
 
+	omrtty_printf("{\t PRINT [LookBack]: normalizedInitialGenerationSize (%zu)}\n", normalizedInitialGenerationSize);
 	for (uintptr_t age = 0; age <= OBJECT_HEADER_AGE_MAX + 1; ++age) {
 		/* skip the first row (it's the current scavenge, and is all zero right now).
 		 * Also skip the last row in the history (there's no previous to compare it to)
 		 */
+
+		omrtty_printf("\n \n \t \t PRINT LookBack Loop for AGE (%zu)}\n", age);
+
 		bool shouldTenureThisAge = true;
 		uintptr_t currentGenerationBytes = stats->getFlipHistory(1)->_flipBytes[age];
 
@@ -4481,18 +4526,28 @@ MM_Scavenger::calculateTenureMaskUsingLookback(double minimumSurvivalRate)
 		 * If the generation would occupy at least an eighth of survivor space, look back three collections.
 		 * . . .
 		 */
+		omrtty_printf("\t \t \t ------------------Adjust minimumBytesForRequiredLookback Loop Start--------------------- \n");
+
 		const uintptr_t maximumLookback = SCAVENGER_FLIP_HISTORY_SIZE - 1;
 		uintptr_t requiredLookback = 1;
 		uintptr_t minimumBytesForRequiredLookback = normalizedInitialGenerationSize;
 		while ((requiredLookback < maximumLookback) && (currentGenerationBytes < minimumBytesForRequiredLookback)) {
 			requiredLookback += 1;
 			minimumBytesForRequiredLookback /= 2;
+
+			omrtty_printf("\t \t \t PRINT [LookBack]: requiredLookback (%zu) minimumBytesForRequiredLookback (%zu)}\n", requiredLookback, minimumBytesForRequiredLookback);
 		}
+
+		omrtty_printf("\t \t \t ------------------Adjust minimumBytesForRequiredLookback Loop End--------------------- \n");
+
+		omrtty_printf("{\n \t \t  PRINT [LookBack]: maximumLookback (%zu), requiredLookback (%zu) minimumBytesForRequiredLookback (%zu) currentGenerationBytes (%zu) }\n", maximumLookback, requiredLookback, minimumBytesForRequiredLookback, currentGenerationBytes);
 
 		if (requiredLookback >= age) {
 			/* this generation is too young to have enough history to satisfy the lookback */
+			omrtty_printf("{\t \t PRINT [LookBack]: SHOULD TENURE = FALSE \t (requiredLookback >= age) \n");
 			shouldTenureThisAge = false;
 		} else {
+			omrtty_printf("{\t \t PRINT [LookBack]: ELSE ...requiredLookback < age \n");
 			Assert_MM_true(1 <= requiredLookback);
 			Assert_MM_true(requiredLookback < SCAVENGER_FLIP_HISTORY_SIZE);
 			for (uintptr_t lookback = 1; (lookback <= requiredLookback) && shouldTenureThisAge; lookback++) {
@@ -4505,9 +4560,11 @@ MM_Scavenger::calculateTenureMaskUsingLookback(double minimumSurvivalRate)
 
 				if (0 != previousFlipBytes) {
 					if (0 == currentFlipBytes) {
+						omrtty_printf("{\t \t PRINT [LookBack]: SHOULD TENURE = FALSE \t (0 == currentFlipBytes) \n");
 						/* There are no bytes in this age, don't bother tenuring. */
 						shouldTenureThisAge = false;
 					} else if (((double)currentTotalBytes / (double)previousFlipBytes) < minimumSurvivalRate) {
+						omrtty_printf("{\t \t PRINT [LookBack]: SHOULD TENURE = FALSE \t (currentTotalBytes / (double)previousFlipBytes) < minimumSurvivalRate) \n");
 						/* Not enough objects are surviving, don't tenure. */
 						shouldTenureThisAge = false;
 					}
@@ -4518,6 +4575,7 @@ MM_Scavenger::calculateTenureMaskUsingLookback(double minimumSurvivalRate)
 		if (shouldTenureThisAge) {
 			/* Objects in this age are historically still dying at a rate of less than 1%. Tenure them. */
 			mask |= ((uintptr_t)1 << age);
+			omrtty_printf("{\t \t PRINT [LookBack]: SHOULD TENURE == TRUE, MASK (%zu) \n", mask);
 		}
 	}
 

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -481,7 +481,7 @@ public:
 	 * @param minimumSurvivalRate The minimum survival rate required to consider tenuring.
 	 * @return A tenure mask for the resulting ages to tenure.
 	 */
-	uintptr_t calculateTenureMaskUsingLookback(double minimumSurvivalRate);
+	uintptr_t calculateTenureMaskUsingLookback(double minimumSurvivalRate, MM_EnvironmentStandard *env);
 
 	/**
 	 * The implementation of the History scavenger tenure strategy.
@@ -507,7 +507,7 @@ public:
 	 * Calculates which generations should be tenured in the form of a bit mask.
 	 * @return mask of ages to tenure
 	 */
-	uintptr_t calculateTenureMask();
+	uintptr_t calculateTenureMask(MM_EnvironmentStandard *env);
 
 	/**
 	 * reset LargeAllocateStats in Tenure Space


### PR DESCRIPTION
### Summary
The goal of this investigation is to relax Scavenger's aliasing inhibiting condition _(mechanism used to improve parallelism & GC pause time)_  to increase object locality and ultimately improve application throughput. From Scavenger's aliasing perspective, object locality and parallelism/pause times are inversely proportional. A gain in one will cause a loss in the other, however throughput gains can result from improvements in either. As a result, with correct tuning between the two, optimal throughput gains can be achieved. That is, by tuning aliasing activity, throughput gains can be achieved in two ways:

1. Increasing **parallelism** (results in a decrease in **object locality**)
2. Increasing **object locality** (results in a decrease in **parallelism**)

**By relaxing Scavenger's aliasing inhibiting condition, a better  "equilibrium" between the the two can achieved for optimal throughput gains.** 


_A background has been provided to outline work that's been done in the past which relates to the investigation discussed in this issue._
### Background
In the context of Parallel Scavenger, a thread is said to be stalled if it has no caches to scan. In other words, a thread is left ideal and "starved" when it has exhausted all work. These stalled threads are accounted for by  Scavenger's `_waitingCount` member, which is incremented for each stalled thread.

In the past, an increase in mean GC pause times (Approx. 18%) was observed, it was found to be related to a decrease in parallelism resulting from stalled threads. Overall, this was determined to be a consequence of hierarchical scan aliasing which forces threads to "consume their own produce". Threads with scan work resulting in greater number of cache copies continued running while other threads with less copy work eventually stalled. As a result, threads were stalled for a proportion of GC, parallelism dropped and pause times increased.

To alleviate thread stalling, work sharing was introduced by making aliasing conditional. This would act as a mechanism to inhabit aliasing  and release newly copied work when threads were found to be stalled _(i.e., wait count is greater than 0)_, as outlined in the following code: 

```C++
MMINLINE MM_CopyScanCacheStandard *
MM_Scavenger::aliasToCopyCache(MM_EnvironmentStandard *env, GC_SlotObject *scannedSlot, MM_CopyScanCacheStandard* scanCache, MM_CopyScanCacheStandard* copyCache)
{
	/* Only alias a copy cache IF there are 0 threads waiting.  If the current thread is the only producer and
	 * it aliases a copy cache then it will be the only thread able to consume.  This will alleviate the stalling issues
	 * described in VMDESIGN 1359.
	 *
	 * @NOTE this is likely too aggressive and should be relaxed.
	 */

	if (_waitingCount == 0) {
                ....
		}
	} else if (NULL != env->_deferredScanCache) {
		/* If there are threads waiting and this thread has a deferredScanCache push
		 * it to the scanCache to make work for the stalled threads.
		 */
                  ...
	}
	return NULL;
}
```
**By decreasing pause times (18% reduction) , a increase in throughput was also observed (~0.5%).**

### Investigation
The main objective of this investigation is to look into the condition inhibiting aliasing _( See Background)_. It was noted that: 

> @NOTE this is likely too aggressive and should be relaxed.

Currently, the condition is too aggressive as aliasing is inhibited when any one thread is stalled (_i.e., waitingCount must be 0 for aliasing to occur)_. Aliasing should only be inhibited *when absolutely required* as aliasing results in better object locality and consequently better application throughput. **By being aggressive, we will ensure optimal parallelism, however we may give up throughput improvements.** For this reason, we must look into potential throughput improvements by sacrificing parallelism/GC pause time gains and increasing aliasing. Overall, the benefits and loss of relaxing the aliasing inhibiting condition must be determined. 

 **A favourable gain in throughput with a tolerable loss in GC pause times (decrease in parallelism) is expected with an optimal condition.**

### Testing Methods 
The aim is to find the percentage of GC threads which can be stalled while gaining favourable increase in throughput. Currently 0% of threads can be stalled, hence throughout and pause times data must be gathered for various thresholds. This will be done by benchmarking  an experimental build with a runtime option to modify the threshold:
```C++
if (_waitingCount <=  _extensions->waitCountThreshold) 
```

Benchmarking will be done on a 24 threaded system with the following thresholds: 0 (baseline), 2, 4, 6, 12, 18,  ∞ (no wait count)

Relative gains throughput and pause time will be measured and plotted for analysis.


